### PR TITLE
Groups and blue series

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@
       brightness: 8
       color: 'light pink'
       
+    *** Group with light.* switch.* and fan.* entities ***  
+    service: script.inovelli_led
+    data:
+      group:
+        - group.test_lights
+      LEDcolor: Green  
+      
     service: script.inovelli_led_zwavejs
     data:
       entity: fan.front_porch

--- a/README.md
+++ b/README.md
@@ -31,39 +31,48 @@
     - color: (int or string) Sets color of LED effect and must be one of: Off, Red, Orange, Yellow, Green, Cyan, Teal, Blue, Purple, Light Pink, Pink, White
 
 
-  **Notification effect examples:**
-	
+## Notification effect examples:
+  Area and group values can be IDs or names, mixed as a proper list or a string of comma-separated values.
+
+   **String of comma-separated values**
+   
     service: script.inovelli_led_zwavejs
     data:
-      area: 'Family Room' # This can also be an area ID, if you're using a template.
+      area: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c' 
       duration: Forever
       effect: CHASE
       brightness: 8
       color: Teal
 
+  **'area: all' will find any compatible Inovelli devices in Home Assistant 2023.04 or newer.**
+  
     service: script.inovelli_led_zwavejs
     data:
-      area: all # Requires Home Assistant 2023.04 or newer.
+      area: all
       duration: Forever
       effect: 'Fast Blink'
       brightness: 8
       color: 'light pink'
-      
+
+  **Proper list format**
+  
     service: script.inovelli_led_zwavejs
     data:
-      entity: fan.front_porch
+      group:
+        - group.lights_and_switches
+        - 0249abdc634c12cbf6cdc06d7a507495
       effect: pulse
       brightness: 8
       color: red
       
-  **Clearing an effect**
+## Clearing an effect
   
     service: script.inovelli_led_zwavejs
     data:
       area: 'Family Room'
       entity: fan.front_porch
   
-  **LED color example:**
+## LED color example:
 
     service: script.inovelli_led_zwavejs
     data:
@@ -74,18 +83,17 @@
 
     service: script.inovelli_led
     data:
-      group:
-        - group.test_lights
+      group: group.outside_front_lights
       LEDcolor: Green  
       
-  **LEDbrightness_off example: (maybe part of a nighttime routine?)**
+## LEDbrightness_off example: (maybe part of a nighttime routine?)
 
     service: script.inovelli_led_zwavejs
     data:
       entity: light.office
       LEDbrightness_off: 2
             
-  **Effect to signal LED indicator transition**
+## Effect to signal LED indicator transition
   
     service: script.inovelli_led_zwavejs
     data:
@@ -98,9 +106,9 @@
       color: green
       brightness: 7
 
-  **Automation to listen for a config button press and set everything in the area to "pulse"**
+## Automation to listen for a config button press and set everything in the area to "pulse"
   
-  This automation listens for a config / 3rd button press, checks in the condition stage that it's an Inovelli device, toggles an input_boolean for the area of the device, then sets or clears an effect on every Inovelli device in the area depending on the new state of the boolean.  I use that boolean in other automations to disable lighting controls.  
+  This automation listens for a config / 3rd button press, checks in the condition stage that it's an Inovelli device, toggles an input_boolean for the area of the device (set this up separately), then sets or clears an effect on every Inovelli device in the area depending on the new state of the boolean.  I use that boolean in other automations to disable lighting controls (like motion timeouts).  
       
     alias: Light Locks
     description: ''

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 
 ## Notification effect examples:
-  Area and group values can be IDs or names, mixed as a proper list or a string of comma-separated values.
+  Area and group values can be IDs or names, mixed as a proper list or a string of comma-separated values.  Entities must use the entity name, and devices must use the device ID.
 
    **String of comma-separated values**
    
@@ -66,6 +66,8 @@
       color: red
       
 ## Clearing an effect
+
+  ** Mix and match areas, groups, devices, and entities **
   
     service: script.inovelli_led_zwavejs
     data:
@@ -76,7 +78,9 @@
 
     service: script.inovelli_led_zwavejs
     data:
-      entity: light.office
+      device:
+        - 531d79e9270d72d9cab44a4f295967d4
+        - ef82d0eb91499feadf45e257c0e5eda1
       LEDcolor: blue
       LEDbrightness: 7
       LEDbrightness_off: 3

--- a/README.md
+++ b/README.md
@@ -49,13 +49,6 @@
       brightness: 8
       color: 'light pink'
       
-    *** Group with light.* switch.* and fan.* entities ***  
-    service: script.inovelli_led
-    data:
-      group:
-        - group.test_lights
-      LEDcolor: Green  
-      
     service: script.inovelli_led_zwavejs
     data:
       entity: fan.front_porch
@@ -79,6 +72,12 @@
       LEDbrightness: 7
       LEDbrightness_off: 3
 
+    service: script.inovelli_led
+    data:
+      group:
+        - group.test_lights
+      LEDcolor: Green  
+      
   **LEDbrightness_off example: (maybe part of a nighttime routine?)**
 
     service: script.inovelli_led_zwavejs

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -17,7 +17,7 @@ alias: Inovelli LED Settings and Effects
 ############
 description: >-
   Handles setting the LED colors and notifications on Inovelli "Red" and "Blue"
-  model switches and dimmers through the Zwave JS and zigbee2mqtt integrations
+  model switches and dimmers through the Zwave JS and zigbee2mqtt integrations.
 mode: parallel
 max: 100 # Default max is 10, which might be an issue if you have a lot of switches
 
@@ -40,10 +40,10 @@ fields:
   group:
     name: Group
     description: >-
-      Group IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN,
-      VZW31-SN devices.  Mix and match types as you like
+      Group names IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN,
+      VZW31-SN devices.  Mix and match types as you like.
     required: false
-    example: "['0249abdc634c12cbf6cdc06d7a507495']"
+    example: "['group.lights_and_switches', '0249abdc634c12cbf6cdc06d7a507495']"
     selector:
       entity:
         multiple: true
@@ -57,7 +57,7 @@ fields:
     name: Device
     description: >-
       Device IDs for Inovelli LZW36, LZW30-SN, LZW31-SN, VZM31-SN, VZW31-SN
-      device IDs.  Mix and match types as you like
+      device IDs.  Mix and match types as you like.
     required: false
     example: "['0249abdc634c12cbf6cdc06d7a507495']"
     selector:
@@ -98,7 +98,7 @@ fields:
 
   LEDcolor:
     name: LED Color (non-effect)
-    description: Sets the color of the LED status, which indicates brightness levels
+    description: Sets the color of the LED status, which indicates brightness levels.
     required: false
     example: Blue
     selector:
@@ -119,7 +119,7 @@ fields:
           - White
   LEDbrightness:
     name: LED Brightness On (non-effect)
-    description: Sets the brightness of the LED status when on. 0 means off
+    description: Sets the brightness of the LED status when on. 0 means off.
     required: false
     example: "6"
     selector:
@@ -130,7 +130,7 @@ fields:
         mode: slider
   LEDbrightness_off:
     name: LED Brightness When Off (non-effect)
-    description: Sets the brightness of the LED status when off. 0 means off
+    description: Sets the brightness of the LED status when off. 0 means off.
     required: false
     example: "2"
     selector:
@@ -201,7 +201,7 @@ fields:
           - Pulse
   brightness:
     name: Effect Brightness
-    description: Sets the brightness of the LED's effect.  0 means off
+    description: Sets the brightness of the LED's effect.  0 means off.
     required: false
     example: "8"
     selector:

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -40,7 +40,7 @@ fields:
   group:
     name: Group
     description: >-
-      Group names IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN,
+      Group names or IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN,
       VZW31-SN devices.  Mix and match types as you like.
     required: false
     example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -439,6 +439,8 @@ variables:
     {% set area_array = namespace(area_list=[]) %}
     {% set entities = namespace(entities=[]) %}
     {% if area != 'invalid' %}
+      {# I'd like to handle 'all' as a list for templating simplicity #}
+      {# changing this to 'all' in area would trigger an area named 'all upstairs' #}
       {% if area == 'all' %}
         {% set area_array.area_list = areas() %}
 
@@ -487,10 +489,8 @@ variables:
       {% for group in group_array.group_list %}
         {% for entity in expand(group) %}
           {% set ent = entity.entity_id %}
-          {% if ent.split('.')[0] == 'light' %}
-            {% if ent.split('.')[0] in allowed_domains %}
-              {% set entities.entities = entities.entities + [ent|string|trim] %}
-            {% endif %}
+          {% if ent.split('.')[0] in allowed_domains %}
+            {% set entities.entities = entities.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
       {% endfor %}

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -26,7 +26,7 @@ fields:
     name: Area
     description: Area names or IDs containing Inovelli devices.
     required: false
-    example: "['Family Room']"
+    example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
     selector:
       area:
         multiple: true
@@ -43,7 +43,7 @@ fields:
       Group names IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN,
       VZW31-SN devices.  Mix and match types as you like.
     required: false
-    example: "['group.lights_and_switches', '0249abdc634c12cbf6cdc06d7a507495']"
+    example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
     selector:
       entity:
         multiple: true
@@ -59,7 +59,7 @@ fields:
       Device IDs for Inovelli LZW36, LZW30-SN, LZW31-SN, VZM31-SN, VZW31-SN
       device IDs.  Mix and match types as you like.
     required: false
-    example: "['0249abdc634c12cbf6cdc06d7a507495']"
+    example: '0249abdc634c12cbf6cdc06d7a507495'
     selector:
       device:
         multiple: true

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -49,6 +49,7 @@ fields:
         multiple: true
         filter:
           - domain:
+              - group
               - fan
               - light
               - switch

--- a/inovelli_led_zwave.yaml
+++ b/inovelli_led_zwave.yaml
@@ -1,5 +1,5 @@
-alias: Inovelli Zwave Dimmer and Switch LEDs
-description: 'Handles setting the switch and dimmer LED colors and notifications'
+alias: Inovelli Dimmer and Switch LEDs
+description: 'This script is unmaintained and not receiving updates since the old Open Z-Wave 1.4 was deprecated in Home Assistant.  Handles setting the switch and dimmer LED colors and notifications'
 ############
 # To make this script work with the new open z-wave 1.6, the "service" in each step needs to be changed.
 # I'd like to automagically detect if 1.4 or 1.6 is being used and then change to service_templates, but I'm not sure how to do that without requiring a sensor or adding yet another parameter that needs to be passed.

--- a/inovelli_led_zwavejs.yaml
+++ b/inovelli_led_zwavejs.yaml
@@ -1,4 +1,4 @@
-alias: Inovelli LED Settings and Effects (Zwave)
+alias: Inovelli Dimmer and Switch LEDs ZwaveJS
 description: 'Handles setting the LED colors and notifications on Inovelli "Red" model switches and dimmers through the Zwave JS integration with zwavejs2mqtt 2.4.0 using webhooks.'
 ############
 # Caculations: https://docs.google.com/spreadsheets/d/14wTP4OL4hkDK3Et5kYL4fyxPIK_R9JR3cgFxSa6dhyw/edit?usp=sharing
@@ -176,7 +176,7 @@ fields:
 
   effect:
     name: Effect
-    description: Type of effect
+    description: Type of effect. NOTE – Chase is not available on devices of type switch and will blink instead.
     required: no
     example: Pulse
     selector:

--- a/inovelli_led_zwavejs.yaml
+++ b/inovelli_led_zwavejs.yaml
@@ -34,9 +34,9 @@ fields:
 
   group:
     name: Group
-    description: Group IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN devices.  Mix and match types as you like
+    description: Group names or IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN devices.  Mix and match types as you like
     required: no
-    example: "['0249abdc634c12cbf6cdc06d7a507495']"
+    example: "['group.lights_and_switches', '0249abdc634c12cbf6cdc06d7a507495']"
     selector:
       entity:
         multiple: true
@@ -45,6 +45,7 @@ fields:
               - fan
               - light
               - switch
+              - group
 
   device:
     name: Device

--- a/inovelli_led_zwavejs.yaml
+++ b/inovelli_led_zwavejs.yaml
@@ -42,10 +42,10 @@ fields:
         multiple: true
         filter:
           - domain:
+              - group
               - fan
               - light
               - switch
-              - group
 
   device:
     name: Device
@@ -484,7 +484,7 @@ variables:
     {{ switch.entities|lower }}
   group_switch: >
     {% set group_array = namespace(group_list=[]) %}
-    {% set dimmer = namespace(entities=[]) %}
+    {% set switch = namespace(entities=[]) %}
     {% if group != 'invalid' %}
       {# Converting to a list#}
       {% if ',' in group %}
@@ -497,22 +497,22 @@ variables:
       {% else %}
         {% set group_array.group_list = group %}
       {% endif %}
-      {# Detecting dimmers#}
+      {# Detecting switches #}
       {% for group in group_array.group_list %}
         {% for entity in expand(group) %}
           {% set ent = entity.entity_id %}
-          {% if is_device_attr(ent,'model','LZW30-SN') and ent.split('.')[0] == 'light' %}
-            {% set dimmer.entities = dimmer.entities + [ent|string|trim] %}
+          {% if is_device_attr(ent,'model','LZW30-SN') and ent.split('.')[0] == 'switch' %}
+            {% set switch.entities = switch.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
       {% endfor %}
     {% endif %}
-    {{ dimmer.entities|lower }}
+    {{ switch.entities|lower }}
   device_switch: >
     {% set devices = namespace(devices=[]) %}
     {% set switch = namespace(entities=[]) %}
     {% if device != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in device %}
         {% set devicenum = device.split( ',' ) | count %}
         {% for i in range(0,devicenum) %}
@@ -523,7 +523,7 @@ variables:
         {% else %}
           {% set devices.devices = device %}
       {% endif %}
-      {# Detecting switches#}
+      {# Detecting switches #}
       {% for device in devices.devices %}
         {% for ent in device_entities(device) %}
           {% if is_device_attr(ent,'model','LZW30-SN') and ent.split('.')[0] == 'switch' %}
@@ -537,7 +537,7 @@ variables:
     {% set entities = namespace(entities=[]) %}
     {% set switch = namespace(entities=[]) %}
     {% if entity != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in entity %}
         {% set entitynum = entity.split( ',' ) | count %}
         {% for i in range(0,entitynum) %}
@@ -548,7 +548,7 @@ variables:
         {% else %}
           {% set entities.entities = entity %}
       {% endif %}
-      {# Detecting switches#}
+      {# Detecting switches #}
       {% for ent in entities.entities %}
         {% if is_device_attr(ent,'model','LZW30-SN') and ent.split('.')[0] == 'switch' %}
           {% set switch.entities = switch.entities + [ent|string|trim] %}
@@ -563,7 +563,7 @@ variables:
     {% if area != 'invalid' %}
       {% if area == 'all' %}
         {% set area_array.area_list = areas() %}
-      {# Converting to a list#}
+      {# Converting to a list #}
         {% elif ',' in area %}
           {% set areanum = area.split( ',' ) | count %}
           {% for i in range(0,areanum) %}
@@ -574,7 +574,7 @@ variables:
         {% else %}
           {% set area_array.area_list = area %}
       {% endif %}
-      {# Detecting combo_lights#}
+      {# Detecting combo_lights #}
       {% for area in area_array.area_list %}
         {% for ent in area_entities(area) %}
           {% if is_device_attr(ent,'model','LZW36') and ent.split('.')[0] == 'light' %}
@@ -588,7 +588,7 @@ variables:
     {% set group_array = namespace(group_list=[]) %}
     {% set dimmer = namespace(entities=[]) %}
     {% if group != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in group %}
         {% set groupnum = group.split( ',' ) | count %}
         {% for i in range(0,groupnum) %}
@@ -599,7 +599,7 @@ variables:
       {% else %}
         {% set group_array.group_list = group %}
       {% endif %}
-      {# Detecting dimmers#}
+      {# Detecting dimmers #}
       {% for group in group_array.group_list %}
         {% for entity in expand(group) %}
           {% set ent = entity.entity_id %}
@@ -614,7 +614,7 @@ variables:
     {% set devices = namespace(devices=[]) %}
     {% set combo_light = namespace(entities=[]) %}
     {% if device != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in device %}
         {% set devicenum = device.split( ',' ) | count %}
         {% for i in range(0,devicenum) %}
@@ -625,7 +625,7 @@ variables:
         {% else %}
           {% set devices.devices = device %}
       {% endif %}
-      {# Detecting combo_lights#}
+      {# Detecting combo_lights #}
       {% for device in devices.devices %}
         {% for ent in device_entities(device) %}
           {% if is_device_attr(ent,'model','LZW36') and ent.split('.')[0] == 'light' %}
@@ -639,7 +639,7 @@ variables:
     {% set entities = namespace(entities=[]) %}
     {% set combo_light = namespace(entities=[]) %}
     {% if entity != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in entity %}
         {% set entitynum = entity.split( ',' ) | count %}
         {% for i in range(0,entitynum) %}
@@ -650,7 +650,7 @@ variables:
         {% else %}
           {% set entities.entities = entity %}
       {% endif %}
-      {# Detecting combo_lights#}
+      {# Detecting combo_lights #}
       {% for ent in entities.entities %}
         {% if is_device_attr(ent,'model','LZW36') and ent.split('.')[0] == 'light' %}
           {% set combo_light.entities = combo_light.entities + [ent|string|trim] %}
@@ -665,7 +665,7 @@ variables:
     {% if area != 'invalid' %}
       {% if area == 'all' %}
         {% set area_array.area_list = areas() %}
-      {# Converting to a list#}
+      {# Converting to a list #}
         {% elif ',' in area %}
           {% set areanum = area.split( ',' ) | count %}
           {% for i in range(0,areanum) %}
@@ -676,7 +676,7 @@ variables:
         {% else %}
           {% set area_array.area_list = area %}
       {% endif %}
-      {# Detecting combo_fans#}
+      {# Detecting combo_fans #}
       {% for area in area_array.area_list %}
         {% for ent in area_entities(area) %}
           {% if is_device_attr(ent,'model','LZW36') and ent.split('.')[0] == 'fan' %}
@@ -688,9 +688,9 @@ variables:
     {{ combo_fan.entities|lower }}
   group_combo_fan: >
     {% set group_array = namespace(group_list=[]) %}
-    {% set dimmer = namespace(entities=[]) %}
+    {% set combo_fan = namespace(entities=[]) %}
     {% if group != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in group %}
         {% set groupnum = group.split( ',' ) | count %}
         {% for i in range(0,groupnum) %}
@@ -701,17 +701,17 @@ variables:
       {% else %}
         {% set group_array.group_list = group %}
       {% endif %}
-      {# Detecting dimmers#}
+      {# Detecting combo_fans #}
       {% for group in group_array.group_list %}
         {% for entity in expand(group) %}
           {% set ent = entity.entity_id %}
-          {% if is_device_attr(ent,'model','LZW36') and ent.split('.')[0] == 'light' %}
-            {% set dimmer.entities = dimmer.entities + [ent|string|trim] %}
+          {% if is_device_attr(ent,'model','LZW36') and ent.split('.')[0] == 'fan' %}
+            {% set combo_fan.entities = combo_fan.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
       {% endfor %}
     {% endif %}
-    {{ dimmer.entities|lower }}
+    {{ combo_fan.entities|lower }}
   device_combo_fan: >
     {% set devices = namespace(devices=[]) %}
     {% set combo_fan = namespace(entities=[]) %}

--- a/inovelli_led_zwavejs.yaml
+++ b/inovelli_led_zwavejs.yaml
@@ -34,7 +34,7 @@ fields:
 
   group:
     name: Group
-    description: Group names or IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN devices.  Mix and match types as you like
+    description: Group names or IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN devices.  Mix and match types as you like.
     required: no
     example: "['group.lights_and_switches', '0249abdc634c12cbf6cdc06d7a507495']"
     selector:
@@ -49,7 +49,7 @@ fields:
 
   device:
     name: Device
-    description: Device IDs for Inovelli LZW36, LZW30-SN, LZW31-SN device IDs.  Mix and match types as you like
+    description: Device IDs for Inovelli LZW36, LZW30-SN, LZW31-SN device IDs.  Mix and match types as you like.
     required: no
     example: "['0249abdc634c12cbf6cdc06d7a507495']"
     selector:
@@ -84,7 +84,7 @@ fields:
 
   LEDcolor:
     name: LED Color (non-effect)
-    description: Sets the color of the LED status, which indicates brightness levels
+    description: Sets the color of the LED status, which indicates brightness levels.
     required: no
     example: Blue
     selector:
@@ -106,7 +106,7 @@ fields:
 
   LEDbrightness:
     name: LED Brightness On (non-effect)
-    description: Sets the brightness of the LED status when on. 0 means off
+    description: Sets the brightness of the LED status when on. 0 means off.
     required: no
     example: 6
     selector:
@@ -118,7 +118,7 @@ fields:
 
   LEDbrightness_off:
     name: LED Brightness Off (non-effect)
-    description: Sets the brightness of the LED status when off. 0 means off
+    description: Sets the brightness of the LED status when off. 0 means off.
     required: no
     example: 2
     selector:
@@ -192,7 +192,7 @@ fields:
 
   brightness:
     name: Effect Brightness
-    description: Sets the brightness of the LED's effect.  0 means off
+    description: Sets the brightness of the LED's effect.  0 means off.
     required: no
     example: 8
     selector:
@@ -306,7 +306,7 @@ variables:
     "pulse": 5
 
 ##################
-# There's a lot of redundancy here, but it should be easy to update if parameter names change for one model and not another
+# There's a lot of redundancy here, but it should be easy to update if parameter names change for one model and not another.
 ##################
   parameters:
     "dimmer_effect_bulk": 16
@@ -359,7 +359,7 @@ variables:
     {% if area != 'invalid' %}
       {% if area == 'all' %}
         {% set area_array.area_list = areas() %}
-      {# Converting to a list#}
+      {# Converting to a list #}
         {% elif ',' in area %}
           {% set areanum = area.split( ',' ) | count %}
           {% for i in range(0,areanum) %}
@@ -370,7 +370,7 @@ variables:
         {% else %}
           {% set area_array.area_list = area %}
       {% endif %}
-      {# Detecting dimmers#}
+      {# Detecting dimmers #}
       {% for area in area_array.area_list %}
         {% for ent in area_entities(area) %}
           {% if is_device_attr(ent,'model','LZW31-SN') and ent.split('.')[0] == 'light' %}
@@ -384,7 +384,7 @@ variables:
     {% set group_array = namespace(group_list=[]) %}
     {% set dimmer = namespace(entities=[]) %}
     {% if group != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in group %}
         {% set groupnum = group.split( ',' ) | count %}
         {% for i in range(0,groupnum) %}
@@ -395,7 +395,7 @@ variables:
       {% else %}
         {% set group_array.group_list = group %}
       {% endif %}
-      {# Detecting dimmers#}
+      {# Detecting dimmers #}
       {% for group in group_array.group_list %}
         {% for entity in expand(group) %}
           {% set ent = entity.entity_id %}
@@ -410,7 +410,7 @@ variables:
     {% set devices = namespace(devices=[]) %}
     {% set dimmer = namespace(entities=[]) %}
     {% if device != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in device %}
         {% set devicenum = device.split( ',' ) | count %}
         {% for i in range(0,devicenum) %}
@@ -421,7 +421,7 @@ variables:
         {% else %}
           {% set devices.devices = device %}
       {% endif %}
-      {# Detecting dimmers#}
+      {# Detecting dimmers #}
       {% for device in devices.devices %}
         {% for ent in device_entities(device) %}
           {% if is_device_attr(ent,'model','LZW31-SN') and ent.split('.')[0] == 'light' %}
@@ -435,7 +435,7 @@ variables:
     {% set entities = namespace(entities=[]) %}
     {% set dimmer = namespace(entities=[]) %}
     {% if entity != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in entity %}
         {% set entitynum = entity.split( ',' ) | count %}
         {% for i in range(0,entitynum) %}
@@ -446,7 +446,7 @@ variables:
         {% else %}
           {% set entities.entities = entity %}
       {% endif %}
-      {# Detecting dimmers#}
+      {# Detecting dimmers #}
       {% for ent in entities.entities %}
         {% if is_device_attr(ent,'model','LZW31-SN') and ent.split('.')[0] == 'light' %}
           {% set dimmer.entities = dimmer.entities + [ent|string|trim] %}
@@ -461,18 +461,18 @@ variables:
     {% if area != 'invalid' %}
       {% if area == 'all' %}
         {% set area_array.area_list = areas() %}
-      {# Converting to a list#}
+      {# Converting to a list #}
         {% elif ',' in area %}
           {% set areanum = area.split( ',' ) | count %}
           {% for i in range(0,areanum) %}
             {% set area_array.area_list = area_array.area_list + [area.split( ',' )[i]|string|trim ] %}
           {% endfor %}
-        {% elif area[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif area[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set area_array.area_list = area_array.area_list + [area|string|trim] %}
         {% else %}
           {% set area_array.area_list = area %}
       {% endif %}
-      {# Detecting switches#}
+      {# Detecting switches #}
       {% for area in area_array.area_list %}
         {% for ent in area_entities(area) %}
           {% if is_device_attr(ent,'model','LZW30-SN') and ent.split('.')[0] == 'switch' %}
@@ -486,7 +486,7 @@ variables:
     {% set group_array = namespace(group_list=[]) %}
     {% set switch = namespace(entities=[]) %}
     {% if group != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in group %}
         {% set groupnum = group.split( ',' ) | count %}
         {% for i in range(0,groupnum) %}
@@ -518,7 +518,7 @@ variables:
         {% for i in range(0,devicenum) %}
           {% set devices.devices = devices.devices + [device.split( ',' )[i]|string|trim ] %}
         {% endfor %}
-        {% elif device[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif device[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set devices.devices = devices.devices + [device|string|trim] %}
         {% else %}
           {% set devices.devices = device %}
@@ -543,7 +543,7 @@ variables:
         {% for i in range(0,entitynum) %}
           {% set entities.entities = entities.entities + [entity.split( ',' )[i]|string|trim ] %}
         {% endfor %}
-        {% elif entity[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif entity[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set entities.entities = entities.entities + [entity|string|trim] %}
         {% else %}
           {% set entities.entities = entity %}
@@ -569,7 +569,7 @@ variables:
           {% for i in range(0,areanum) %}
             {% set area_array.area_list = area_array.area_list + [area.split( ',' )[i]|string|trim ] %}
           {% endfor %}
-        {% elif area[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif area[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set area_array.area_list = area_array.area_list + [area|string|trim] %}
         {% else %}
           {% set area_array.area_list = area %}
@@ -620,7 +620,7 @@ variables:
         {% for i in range(0,devicenum) %}
           {% set devices.devices = devices.devices + [device.split( ',' )[i]|string|trim ] %}
         {% endfor %}
-        {% elif device[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif device[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set devices.devices = devices.devices + [device|string|trim] %}
         {% else %}
           {% set devices.devices = device %}
@@ -645,7 +645,7 @@ variables:
         {% for i in range(0,entitynum) %}
           {% set entities.entities = entities.entities + [entity.split( ',' )[i]|string|trim ] %}
         {% endfor %}
-        {% elif entity[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif entity[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set entities.entities = entities.entities + [entity|string|trim] %}
         {% else %}
           {% set entities.entities = entity %}
@@ -671,7 +671,7 @@ variables:
           {% for i in range(0,areanum) %}
             {% set area_array.area_list = area_array.area_list + [area.split( ',' )[i]|string|trim ] %}
           {% endfor %}
-        {% elif area[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif area[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set area_array.area_list = area_array.area_list + [area|string|trim] %}
         {% else %}
           {% set area_array.area_list = area %}
@@ -716,18 +716,18 @@ variables:
     {% set devices = namespace(devices=[]) %}
     {% set combo_fan = namespace(entities=[]) %}
     {% if device != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in device %}
         {% set devicenum = device.split( ',' ) | count %}
         {% for i in range(0,devicenum) %}
           {% set devices.devices = devices.devices + [device.split( ',' )[i]|string|trim ] %}
         {% endfor %}
-        {% elif device[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif device[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set devices.devices = devices.devices + [device|string|trim] %}
         {% else %}
           {% set devices.devices = device %}
       {% endif %}
-      {# Detecting combo_fans#}
+      {# Detecting combo_fans #}
       {% for device in devices.devices %}
         {% for ent in device_entities(device) %}
           {% if is_device_attr(ent,'model','LZW36') and ent.split('.')[0] == 'fan' %}
@@ -741,18 +741,18 @@ variables:
     {% set entities = namespace(entities=[]) %}
     {% set combo_fan = namespace(entities=[]) %}
     {% if entity != 'invalid' %}
-      {# Converting to a list#}
+      {# Converting to a list #}
       {% if ',' in entity %}
         {% set entitynum = entity.split( ',' ) | count %}
         {% for i in range(0,entitynum) %}
           {% set entities.entities = entities.entities + [entity.split( ',' )[i]|string|trim ] %}
         {% endfor %}
-        {% elif entity[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity#}
+        {% elif entity[0]|count == 1 %} {# if the first item in the list has only a single character, it can't be a valid entity #}
           {% set entities.entities = entities.entities + [entity|string|trim] %}
         {% else %}
           {% set entities.entities = entity %}
       {% endif %}
-      {# Detecting combo_fans#}
+      {# Detecting combo_fans #}
       {% for ent in entities.entities %}
         {% if is_device_attr(ent,'model','LZW36') and ent.split('.')[0] == 'fan' %}
           {% set combo_fan.entities = combo_fan.entities + [ent|string|trim] %}

--- a/inovelli_led_zwavejs.yaml
+++ b/inovelli_led_zwavejs.yaml
@@ -858,10 +858,6 @@ sequence:
                  duration != "invalid" and
                  brightness != 11 }}
             sequence:
-              - service: notify.mobile_app_phone_scott
-                data:
-                  message: '{{ repeat.item.entities }}'
-
               - service: zwave_js.bulk_set_partial_config_parameters
                 data:
                   entity_id: '{{ repeat.item.entities }}'

--- a/inovelli_led_zwavejs.yaml
+++ b/inovelli_led_zwavejs.yaml
@@ -23,7 +23,7 @@ fields:
     name: Area
     description: Area names or IDs containing Inovelli devices.
     required: no
-    example: "['Family Room']"
+    example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
     selector:
       area:
         multiple: true
@@ -36,7 +36,7 @@ fields:
     name: Group
     description: Group names or IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN devices.  Mix and match types as you like.
     required: no
-    example: "['group.lights_and_switches', '0249abdc634c12cbf6cdc06d7a507495']"
+    example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
     selector:
       entity:
         multiple: true
@@ -51,7 +51,7 @@ fields:
     name: Device
     description: Device IDs for Inovelli LZW36, LZW30-SN, LZW31-SN device IDs.  Mix and match types as you like.
     required: no
-    example: "['0249abdc634c12cbf6cdc06d7a507495']"
+    example: '0249abdc634c12cbf6cdc06d7a507495'
     selector:
       device:
         multiple: true


### PR DESCRIPTION
- Adding support for Inovelli's "Blue Series" devices, thanks to @smenzer!
- Adding support for devices in groups, thanks to @smenzer!  These groups can be of the light.* or group.* domain, and any combo of Blue or Red series switches, dimmers, or fan / light combo devices.  