### PR TITLE
ZHA continue on error

### DIFF
--- a/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
+++ b/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
@@ -2088,6 +2088,7 @@ sequence:
                                             - "all"
                                           sequence:
                                             - service: zha.set_zigbee_cluster_attribute
+                                              continue_on_error: true
                                               data:
                                                 ieee: "{{ (device_attr( entity, 'identifiers') | list).0.1 }}"
                                                 endpoint_id: 1
@@ -2117,6 +2118,7 @@ sequence:
                                   - conditions: "{{ 'all' not in LEDcolor and LEDcolor != 'no change' }}"
                                     sequence:
                                       - service: zha.set_zigbee_cluster_attribute
+                                        continue_on_error: true
                                         data:
                                           ieee: "{{ (device_attr( repeat.item, 'identifiers') | list).0.1 }}"
                                           endpoint_id: 1
@@ -2277,6 +2279,7 @@ sequence:
                                             - "all"
                                           sequence:
                                             - service: zha.set_zigbee_cluster_attribute
+                                              continue_on_error: true
                                               data:
                                                 ieee: "{{ (device_attr( entity, 'identifiers') | list).0.1 }}"
                                                 endpoint_id: 1
@@ -2306,6 +2309,7 @@ sequence:
                                   - conditions: "{{ 'all' not in LEDcolor_off and LEDcolor_off != 'no change' }}"
                                     sequence:
                                       - service: zha.set_zigbee_cluster_attribute
+                                        continue_on_error: true
                                         data:
                                           ieee: "{{ (device_attr( repeat.item, 'identifiers') | list).0.1 }}"
                                           endpoint_id: 1
@@ -2462,6 +2466,7 @@ sequence:
                                             - "all"
                                           sequence:
                                             - service: zha.set_zigbee_cluster_attribute
+                                              continue_on_error: true
                                               data:
                                                 ieee: "{{ (device_attr( entity, 'identifiers') | list).0.1 }}"
                                                 endpoint_id: 1
@@ -2491,6 +2496,7 @@ sequence:
                                   - conditions: "{{ int(LEDbrightness) != 11 and LEDnumber != 'all' or 'all' not in LEDcolor }}"
                                     sequence:
                                       - service: zha.set_zigbee_cluster_attribute
+                                        continue_on_error: true
                                         data:
                                           ieee: "{{ (device_attr( repeat.item, 'identifiers') | list).0.1 }}"
                                           endpoint_id: 1
@@ -2640,6 +2646,7 @@ sequence:
                                             - "all"
                                           sequence:
                                             - service: zha.set_zigbee_cluster_attribute
+                                              continue_on_error: true
                                               data:
                                                 ieee: "{{ (device_attr( entity, 'identifiers') | list).0.1 }}"
                                                 endpoint_id: 1
@@ -2669,6 +2676,7 @@ sequence:
                                   - conditions: "{{ int(LEDbrightness_off) != 11 and LEDnumber != 'all' or 'all' not in LEDcolor_off }}"
                                     sequence:
                                       - service: zha.set_zigbee_cluster_attribute
+                                        continue_on_error: true
                                         data:
                                           ieee: "{{ (device_attr( repeat.item, 'identifiers') | list).0.1 }}"
                                           endpoint_id: 1
@@ -2779,6 +2787,7 @@ sequence:
                             for_each: "{{ repeat.item.entities }} "
                             sequence:
                               - service: zha.issue_zigbee_cluster_command
+                                continue_on_error: true
                                 data:
                                   ieee: "{{ (device_attr(repeat.item, 'identifiers')|list).0.1 }}"
                                   endpoint_id: 1
@@ -2895,6 +2904,7 @@ sequence:
                         for_each: "{{ repeat.item.entities }} "
                         sequence:
                           - service: zha.issue_zigbee_cluster_command
+                            continue_on_error: true
                             data:
                               ieee: "{{ (device_attr(repeat.item, 'identifiers')|list).0.1 }}"
                               endpoint_id: 1

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -2088,6 +2088,7 @@ sequence:
                                             - "all"
                                           sequence:
                                             - service: zha.set_zigbee_cluster_attribute
+                                              continue_on_error: true
                                               data:
                                                 ieee: "{{ (device_attr( entity, 'identifiers') | list).0.1 }}"
                                                 endpoint_id: 1
@@ -2117,6 +2118,7 @@ sequence:
                                   - conditions: "{{ 'all' not in LEDcolor and LEDcolor != 'no change' }}"
                                     sequence:
                                       - service: zha.set_zigbee_cluster_attribute
+                                        continue_on_error: true
                                         data:
                                           ieee: "{{ (device_attr( repeat.item, 'identifiers') | list).0.1 }}"
                                           endpoint_id: 1
@@ -2277,6 +2279,7 @@ sequence:
                                             - "all"
                                           sequence:
                                             - service: zha.set_zigbee_cluster_attribute
+                                              continue_on_error: true
                                               data:
                                                 ieee: "{{ (device_attr( entity, 'identifiers') | list).0.1 }}"
                                                 endpoint_id: 1
@@ -2306,6 +2309,7 @@ sequence:
                                   - conditions: "{{ 'all' not in LEDcolor_off and LEDcolor_off != 'no change' }}"
                                     sequence:
                                       - service: zha.set_zigbee_cluster_attribute
+                                        continue_on_error: true
                                         data:
                                           ieee: "{{ (device_attr( repeat.item, 'identifiers') | list).0.1 }}"
                                           endpoint_id: 1
@@ -2462,6 +2466,7 @@ sequence:
                                             - "all"
                                           sequence:
                                             - service: zha.set_zigbee_cluster_attribute
+                                              continue_on_error: true
                                               data:
                                                 ieee: "{{ (device_attr( entity, 'identifiers') | list).0.1 }}"
                                                 endpoint_id: 1
@@ -2491,6 +2496,7 @@ sequence:
                                   - conditions: "{{ int(LEDbrightness) != 11 and LEDnumber != 'all' or 'all' not in LEDcolor }}"
                                     sequence:
                                       - service: zha.set_zigbee_cluster_attribute
+                                        continue_on_error: true
                                         data:
                                           ieee: "{{ (device_attr( repeat.item, 'identifiers') | list).0.1 }}"
                                           endpoint_id: 1
@@ -2640,6 +2646,7 @@ sequence:
                                             - "all"
                                           sequence:
                                             - service: zha.set_zigbee_cluster_attribute
+                                              continue_on_error: true
                                               data:
                                                 ieee: "{{ (device_attr( entity, 'identifiers') | list).0.1 }}"
                                                 endpoint_id: 1
@@ -2669,6 +2676,7 @@ sequence:
                                   - conditions: "{{ int(LEDbrightness_off) != 11 and LEDnumber != 'all' or 'all' not in LEDcolor_off }}"
                                     sequence:
                                       - service: zha.set_zigbee_cluster_attribute
+                                        continue_on_error: true
                                         data:
                                           ieee: "{{ (device_attr( repeat.item, 'identifiers') | list).0.1 }}"
                                           endpoint_id: 1
@@ -2779,6 +2787,7 @@ sequence:
                             for_each: "{{ repeat.item.entities }} "
                             sequence:
                               - service: zha.issue_zigbee_cluster_command
+                                continue_on_error: true
                                 data:
                                   ieee: "{{ (device_attr(repeat.item, 'identifiers')|list).0.1 }}"
                                   endpoint_id: 1
@@ -2895,6 +2904,7 @@ sequence:
                         for_each: "{{ repeat.item.entities }} "
                         sequence:
                           - service: zha.issue_zigbee_cluster_command
+                            continue_on_error: true
                             data:
                               ieee: "{{ (device_attr(repeat.item, 'identifiers')|list).0.1 }}"
                               endpoint_id: 1


### PR DESCRIPTION
* Addresses [issue 63](https://github.com/kschlichter/Home-Assistant-Inovelli-Effects-and-Colors/issues/63) by adding a `continue_on_error: true` to ZHA calls.  Devices that don't respond still won't be updated but the script will continue and other devices will still be updated.  
* Thank you to [muepla](https://github.com/muepla) for this workaround. 