### PR TITLE
71 white switches now support effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@
 
 ### Notes on White Series devices
 
-  * Speaking of quirks, with firmware 1.1.5 the device only supports LED bar brightness (`LEDbrightness` and `LEDbrightness_off`)levels from the list below.  I'll use the closest match of equal or lesser value.  Setting `LEDbrightness` to 1.3 will result in 13.  Setting it to 99 will result in 90; 100 results in 100.  I'd love to know what problem this list solves and why it couldn't be an `input_number`.
+  * With firmware 1.1.5 the device only supports LED bar brightness (`LEDbrightness` and `LEDbrightness_off`) levels from the list below.  I'll use the closest match of equal or lesser value.  Setting `LEDbrightness` to 1.3 will result in 13.  Setting it to 99 will result in 90; 100 results in 100.  I'd love to know what problem this list solves and why it couldn't be an `input_number`.
     * [0, 1, 3, 5, 8, 10, 13, 16, 20, 23, 26, 30, 33, 36, 40, 45, 50, 60, 70, 80, 90, 100]
-  * The entity IDs for setting the LED bar brightness leves must end in `_on` and `_off`.  There's no way to discern which is which without relying on the `entity_id`.  If you rename them, make sure they end with `_on` and `_off` (e.g. `select.white_series_smart_2_1_switch_led_intensity_on`).
+  * The entity IDs for setting the LED bar brightness levels must end in `_on` and `_off`.  There's no way to discern which is which without relying on the `entity_id`.  If you rename them, make sure they end with `_on` and `_off` (e.g. `select.white_series_smart_2_1_switch_led_intensity_on`).
   * There's no option to set the LED bar to a different color when it's off than when it's on.  The `LEDcolor_off` option is ignored.
-  * Only the colors in the list below are supported.
+  * Only the colors in the list below are supported; not the full 256 colorset. 
     * [Red, Orange, Lemon, Lime, Green, Teal, Cyan, Aqua, Blue, Violet, Magenta, Pink, White]
   * Not all effects are supported.  The effects supported by Red and Blue Series devices, which are not supported by the White Series, have been mapped to something I arbitrarily decided was reasonable.
-  * Effect duration is not supported by the White Series devices.  It must still be defined in order to invoke the effect—otherwise it defaults to "off"—but all effects are necessarily "forever" duration.  A second call must be made to disable the effect.  
+  * Effect duration is not supported by the White Series devices.  It must still be defined in order to invoke the effect—otherwise it defaults to "off"—but all effects are necessarily "forever" duration.  A second call must be made to disable the effect.  You can see examples for clearing effects further down in this document. 
 
 ## Blueprint Installation Instructions
   

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ As a quick start you can follow these steps:
     - duration: (string) Either "Off", or a whole integer followed by "Seconds", "Minutes", "Hours", "Indefinitely", or "Forever".
     - effect: (string) Where older devices and individual LEDs don't support a given effect, that effect has been mapped to something that is supported.
     - brightness: (integer 1 – 10) Sets the brightness of the LED's effect
-    - color: (int or string) Sets color of LED effect and must be one of: "Off", Red, Orange, Lemon, Yellow, Lime, Green, Cyan, Teal, Blue, Purple, Magenta, Light Pink, Pink, Hot Pink, White
+    - color: (int or string) Sets color of LED effect and must be one of: "Off", Red, Orange, Lemon, Yellow, Lime, Green, Cyan, Teal, Aqua, Blue, Purple, Magenta, Violet, Light Pink, Pink, Hot Pink, White
         Color sets like "all usa" cannot be used with effects.  I can't think of a way to get all 7 LEDs synchronized for effects like "pulse" or "chase".
 
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
   * There's no option to set the LED bar to a different color when it's off than when it's on.  The `LEDcolor_off` option is ignored.
   * Only the colors in the list below are supported.
     * [Red, Orange, Lemon, Lime, Green, Teal, Cyan, Aqua, Blue, Violet, Magenta, Pink, White]
+  * Not all effects are supported.  The effects supported by Red and Blue Series devices, which are not supported by the White Series, have been mapped to something I arbitrarily decided was reasonable.
+  * Effect duration is not supported by the White Series devices.  It must still be defined in order to invoke the effect—otherwise it defaults to "off"—but all effects are necessarily "forever" duration.  A second call must be made to disable the effect.  
 
 ## Blueprint Installation Instructions
   

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@
 
 ### Notes on White Series devices
 
-  * **Breaking change:** this only supports White Series devices with firmware 1.1.5 and above.  Inovelli devices in general have a lot of quirks.  Things change with updates to Z2M, ZHA, or Z-Wave JS and also between firmware versions.  As much as possible, I try to work around those nuances to keep the UI and behavior consistent.  The White Series devices have changed significantly with firmware 1.1.5 and I can't find a way to reliably detect which firmware a device has.  I'm assuming firmware 1.1.5 and this script will not work with devices on earlier firmware.
   * Speaking of quirks, with firmware 1.1.5 the device only supports LED bar brightness (`LEDbrightness` and `LEDbrightness_off`)levels from the list below.  I'll use the closest match of equal or lesser value.  Setting `LEDbrightness` to 1.3 will result in 13.  Setting it to 99 will result in 90; 100 results in 100.  I'd love to know what problem this list solves and why it couldn't be an `input_number`.
     * [0, 1, 3, 5, 8, 10, 13, 16, 20, 23, 26, 30, 33, 36, 40, 45, 50, 60, 70, 80, 90, 100]
   * The entity IDs for setting the LED bar brightness leves must end in `_on` and `_off`.  There's no way to discern which is which without relying on the `entity_id`.  If you rename them, make sure they end with `_on` and `_off` (e.g. `select.white_series_smart_2_1_switch_led_intensity_on`).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@
   
   Effects that have been set to "forever" can be cleared by just passing the entity, device, group, label, area, or floor.  There's no need to remember the effect, color, and brightness parameter or set them to 0 in a template.  It's easier to remember when you get to my age, and less to type.  Also, it's a fairly safe way to "fail" if we don't have all the right parameters, since (most of the time) clearing the effect will have no visible result on the physical device.
 
+### Notes on White Series devices
+
+  * **Breaking change:** this only supports White Series devices with firmware 1.1.5 and above.  Inovelli devices in general have a lot of quirks.  Things change with updates to Z2M, ZHA, or Z-Wave JS and also between firmware versions.  As much as possible, I try to work around those nuances to keep the UI and behavior consistent.  The White Series devices have changed significantly with firmware 1.1.5 and I can't find a way to reliably detect which firmware a device has.  I'm assuming firmware 1.1.5 and this script will not work with devices on earlier firmware.
+  * Speaking of quirks, with firmware 1.1.5 the device only supports LED bar brightness (`LEDbrightness` and `LEDbrightness_off`)levels from the list below.  I'll use the closest match of equal or lesser value.  Setting `LEDbrightness` to 1.3 will result in 13.  Setting it to 99 will result in 90; 100 results in 100.  I'd love to know what problem this list solves and why it couldn't be an `input_number`.
+    * [0, 1, 3, 5, 8, 10, 13, 16, 20, 23, 26, 30, 33, 36, 40, 45, 50, 60, 70, 80, 90, 100]
+  * The entity IDs for setting the LED bar brightness leves must end in `_on` and `_off`.  There's no way to discern which is which without relying on the `entity_id`.  If you rename them, make sure they end with `_on` and `_off` (e.g. `select.white_series_smart_2_1_switch_led_intensity_on`).
+  * There's no option to set the LED bar to a different color when it's off than when it's on.  The `LEDcolor_off` option is ignored.
+  * 
 
 ## Blueprint Installation Instructions
   

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@
     * [0, 1, 3, 5, 8, 10, 13, 16, 20, 23, 26, 30, 33, 36, 40, 45, 50, 60, 70, 80, 90, 100]
   * The entity IDs for setting the LED bar brightness leves must end in `_on` and `_off`.  There's no way to discern which is which without relying on the `entity_id`.  If you rename them, make sure they end with `_on` and `_off` (e.g. `select.white_series_smart_2_1_switch_led_intensity_on`).
   * There's no option to set the LED bar to a different color when it's off than when it's on.  The `LEDcolor_off` option is ignored.
-  * 
+  * Only the colors in the list below are supported.
+    * [Red, Orange, Lemon, Lime, Green, Teal, Cyan, Aqua, Blue, Violet, Magenta, Pink, White]
 
 ## Blueprint Installation Instructions
   

--- a/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
+++ b/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
@@ -29,7 +29,7 @@
 #
 # Convert to blueprint:
 #   Switch blueprint: and script alias: lines
-#   Add two spaces to lines between label: and variables: 71,664s
+#   Add two spaces to lines between label: and variables: 71.670s
 #   Comment out example:
 #   Switch input_* and script variables (1 place)
 #
@@ -444,8 +444,10 @@ blueprint:
             - Green
             - Cyan
             - Teal
+            - Aqua
             - Blue
             - Purple
+            - Violet
             - Magenta
             - Light Pink
             - Pink
@@ -485,8 +487,10 @@ blueprint:
             - Green
             - Cyan
             - Teal
+            - Aqua
             - Blue
             - Purple
+            - Violet
             - Magenta
             - Light Pink
             - Pink
@@ -609,8 +613,10 @@ blueprint:
             - Green
             - Cyan
             - Teal
+            - Aqua
             - Blue
             - Purple
+            - Violet
             - Magenta
             - Light Pink
             - Pink
@@ -678,8 +684,10 @@ variables:
     green: 85
     cyan: 127
     teal: 145
+    aqua: 160
     blue: 170
     purple: 190
+    violet: 200
     magenta: 212
     light pink: 220
     pink: 234
@@ -691,6 +699,7 @@ variables:
     "all custom on": "{{ LEDcolor_custom | default({'led 1':255,'led 2':255,'led 3':255,'led 4':255,'led 5':255,'led 6':255,'led 7':255,'all':0}) }}"
     "all custom off": "{{ LEDcolor_off_custom | default({'led 1':255,'led 2':255,'led 3':255,'led 4':255,'led 5':255,'led 6':255,'led 7':255,'all':0}) }}"
 
+  
   ### Blue Series ZHA Quirks says 1 – 7 but it seems to be 0 – 6 ###
   led_map:
     all: -1
@@ -1463,29 +1472,49 @@ variables:
   VTM31SN_all_effects:
     "off": 0
     clear effect: 0
-    aurora: 0
-    blink: 0
-    blink fast: 0
-    blink medium: 0
-    blink slow: 0
-    chase: 0
-    chase fast: 0
-    chase medium: 0
-    chase slow: 0
-    fall fast: 0
-    fall medium: 0
-    fall slow: 0
-    open close: 0
-    pulse: 0
-    rise fast: 0
-    rise medium: 0
-    rise slow: 0
-    siren fast: 0
-    siren slow: 0
-    small to big: 0
-    solid: 0
-    fast blink: 0
-    slow blink: 0
+    aurora: "Middle Chase"
+    blink: "Middle Blink"
+    blink fast: "Fast Blink"
+    blink medium: "Middle Blink"
+    blink slow: "Slow Blink"
+    chase: "Middle Chase"
+    chase fast: "Fast Chase"
+    chase medium: "Middle Chase"
+    chase slow: "Slow Chase"
+    fall fast: "Fast Falling"
+    fall medium: "Middle Falling"
+    fall slow: "Slow Falling"
+    open close: "Open Close"
+    pulse: "Middle Blink"
+    rise fast: "Fast Rising"
+    rise medium: "Middle Rising"
+    rise slow: "Slow Rising"
+    siren fast: "Fast Siren"
+    siren slow: "Slow Siren"
+    small to big: "Small To Big" 
+    solid: Solid
+    fast blink: "Fast Blink"
+    slow blink: "Slow Blink"
+
+  VTM31SN_colors:
+    red: Red
+    orange: Orange
+    lemon: Lemon
+    yellow: Lemon
+    lime: Lime
+    green: Green
+    cyan: Cyan
+    teal: Teal
+    aqua: Aqua
+    blue: Blue
+    purple: Magenta
+    violet: Violet
+    magenta: Magenta
+    light pink: Pink
+    pink: Pink
+    hot pink: Pink
+    white: White
+    "off": White
 
   ### White Series Fan ###
   VTM35SN_all_effects:
@@ -1514,6 +1543,7 @@ variables:
     solid: 0
     fast blink: 0
     slow blink: 0
+  
 
 
   ##################
@@ -2214,20 +2244,113 @@ sequence:
         ##################
         # Matter
         ##################
-        - device_type: VTM31SN
+        - device_type: VTM31SN-115
+          call_type: matter
+
+          effects: "{{ VTM31SN_all_effects[effect] }}"
+
+          entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') >= '1.1.0' %}
+                {% for led_bar in device_entities(device_id(ent)) %}
+                  {% if 'red' in state_attr(led_bar,'options') | lower and led_bar not in entities.entities %}
+                    {% set entities.entities = entities.entities + [led_bar] %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+          brightness_on_entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') >= '1.1.0' %}
+                {% for brightness_on in device_entities(device_id(ent)) %}
+                  {% if '100' in state_attr(brightness_on,'options') | lower and brightness_on.split('_')[-1] == 'on' and brightness_on not in entities.entities %}
+                    {% set entities.entities = entities.entities + [brightness_on] %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+          brightness_on_level: >-
+            {% set brightness = namespace(value=[0]) %}
+            {% for num in [0, 1, 3, 5, 8, 10, 13, 16, 20, 23, 26, 30, 33, 36, 40, 45, 50, 60, 70, 80, 90, 100] %}
+              {% if int(num,default=0) <= ((LEDbrightness | float) *10 | int) %}
+                {% set brightness.value = num %}
+              {% endif %}
+            {% endfor %}
+            {{ brightness.value }}
+
+          brightness_off_entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') >= '1.1.0' %}
+                {% for brightness_off in device_entities(device_id(ent)) %}
+                  {% if '100' in state_attr(brightness_off,'options') | lower and brightness_off.split('_')[-1] == 'off' and brightness_off not in entities.entities %}
+                    {% set entities.entities = entities.entities + [brightness_off] %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+          brightness_off_level: >-
+            {% set brightness = namespace(value=[0]) %}
+            {% for num in [0, 1, 3, 5, 8, 10, 13, 16, 20, 23, 26, 30, 33, 36, 40, 45, 50, 60, 70, 80, 90, 100] %}
+              {% if int(num,default=0) <= ((LEDbrightness_off | float) *10 | int) %}
+                {% set brightness.value = num %}
+              {% endif %}
+            {% endfor %}
+            {{ brightness.value }}
+
+          effect_color_entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for effect_color in all_selected_entities %}
+              {% if 'white series' in (device_attr(effect_color,'model') | lower ) and effect_color.split('.')[0] == 'light' and effect_color in integration_entities('matter') and 'color_temp' in state_attr(effect_color,'supported_color_modes') and
+                    device_attr(device_id(effect_color), 'sw_version') >= '1.1.0' %}
+                {% set entities.entities = entities.entities + [effect_color] %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+          effect_entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') >= '1.1.0' %}
+                {% for effect in device_entities(device_id(ent)) %}
+                  {% if 'solid' in state_attr(effect,'options')|lower and effect not in entities.entities %}
+                    {% set entities.entities = entities.entities + [effect] %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+
+        - device_type: VTM31SN-105
           call_type: matter
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'white series' in (device_attr(ent,'model') | lower ) and not 'color_temp' in state_attr(ent,'supported_color_modes') and ent.split('.')[0] == 'light' and ent in integration_entities('matter') %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and not 'color_temp' in state_attr(ent,'supported_color_modes') and ent.split('.')[0] == 'light' and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') < '1.1.0' %}
                 {% set entities.entities = entities.entities + ['select.' + ent.split('.')[1].split('_light_1')[0] + '_led_color'] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
+
           effect_entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'white series' in (device_attr(ent,'model') | lower ) and 'color_temp' in state_attr(ent,'supported_color_modes') and ent.split('.')[0] == 'light' and ent in integration_entities('matter') %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and 'color_temp' in state_attr(ent,'supported_color_modes') and ent.split('.')[0] == 'light' and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') < '1.1.0' %}
                 {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
@@ -2243,6 +2366,7 @@ sequence:
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
+
           effect_entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
@@ -2443,7 +2567,15 @@ sequence:
                 ### Matter ###
                 ### White Series can't set individual LEDs so we'll filter out color sets and force 'all' ###
                 - choose:
-                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor and LEDnumber == 'all' }}"
+                    ### VTM31-SN FW >= 1.1.0
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor and LEDnumber == 'all' and repeat.item.device_type == 'VTM31SN-115' }}"
+                      sequence:
+                        - service: select.select_option
+                          data:
+                            option: "{{ VTM31SN_colors[LEDcolor] | capitalize }}"
+                            entity_id: "{{ repeat.item.entities }}"
+                    ### VTM31-SN FW < 1.0.5 and VTM35-SN
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor and LEDnumber == 'all' and repeat.item.device_type != 'VTM31SN-115' }}"
                       sequence:
                         - service: select.select_option
                           data:
@@ -2632,6 +2764,9 @@ sequence:
                                             {% endif %}
                                           manufacturer: 4655
 
+                ### Matter ###
+                ### Not supported ###
+
 
         ##################
         # LED strip brightness
@@ -2643,7 +2778,7 @@ sequence:
                 ### Zwave JS ###
                 ### Red Series can't set individual LEDs so we'll filter out color sets and force 'all'.  Prefer no action over partial implimentation of users' intents.  ###
                 - choose:
-                    - conditions: "{{ repeat.item.call_type == 'zwave_js' and 'all' in LEDnumber and 'all' not in LEDcolor and LEDnumber == 'all' }}"
+                    - conditions: "{{ repeat.item.call_type == 'zwave_js' and 'all' not in LEDcolor and LEDnumber == 'all' }}"
                       sequence:
                         - service: zwave_js.set_config_parameter
                           data:
@@ -2812,6 +2947,15 @@ sequence:
                                             {% endif %}
                                           value: "{{ iif(LEDcolor == 'all clear',101,(LEDbrightness * 10)) | int }}"
                                           manufacturer: 4655
+
+                ### Matter ###
+                - choose:
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor and LEDnumber == 'all' and repeat.item.device_type == 'VTM31SN-115' }}"
+                      sequence:
+                        - service: select.select_option
+                          data:
+                            option: "{{ iif(LEDcolor == 'off','0',int(repeat.item.brightness_on_level)) }}"
+                            entity_id: "{{ repeat.item.brightness_on_entities }}"
 
 
         ##################
@@ -2994,6 +3138,16 @@ sequence:
                                           value: "{{ iif(LEDcolor_off == 'all clear',101,(LEDbrightness_off * 10)) | int }}"
                                           manufacturer: 4655
 
+                ### Matter ###
+                - choose:
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor_off and LEDnumber == 'all' and repeat.item.device_type == 'VTM31SN-115' }}"
+                      sequence:
+                        - service: select.select_option
+                          data:
+                            option: "{{ iif(LEDcolor_off == 'off','0',int(repeat.item.brightness_off_level)) }}"
+                            entity_id: "{{ repeat.item.brightness_off_entities }}"
+
+
 
         #################
         # Effects (fully defined)
@@ -3002,7 +3156,7 @@ sequence:
         ##################
         - choose:
             - conditions: >-
-                {{ effect != "off" and effect != "clear effect" and color != "no change" and int(brightness) != 11 and
+                {{ effect != "off" and effect != "clear effect" and color != "no change" and int(brightness) != 11 and duration != 'off' and duration != 0 and 
                    repeat.item.device_type != "LZW30" and repeat.item.device_type != "LZW31" }}
               sequence:
 
@@ -3090,16 +3244,26 @@ sequence:
 
                 ### Matter ###
                 - choose:
-                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' in LEDnumber_effect and 'all' not in color }}"
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' in LEDnumber_effect and 'all' not in color and repeat.item.device_type == 'VTM31SN-115' }}"
                       sequence:
-                        ###  Brightness  ###
+
+                        ###  Effect color and brightness  ###
                         - service: light.turn_on
                           target:
-                            entity_id: "{{ repeat.item.effect_entities }}"
+                            entity_id: "{{ repeat.item.effect_color_entities }}"
                           data:
                             brightness_pct: "{{ (brightness * 10) | int }}"
+                            hs_color: "[{{ ((color_set[color] / 255)*360) | round(1) }}, 100 ]"
 
-                        ### White Series only supports the 'solid' effect ###
+                        ### Effect type ###
+                        - service: select.select_option
+                          data:
+                            option: "{{ repeat.item.effects }}"
+                            entity_id: "{{ repeat.item.effect_entities }}"
+
+                    ### VTM35-SN White Series Fan and VTM31-SN Dimmer FW <1.1.0 only supports the 'solid' effect ###
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' in LEDnumber_effect and 'all' not in color and repeat.item.device_type != 'VTM31SN-115' }}"
+                      sequence:
                         - service: light.turn_on
                           target:
                             entity_id: "{{ repeat.item.effect_entities }}"
@@ -3207,7 +3371,12 @@ sequence:
 
             ### Matter ###
             - choose:
-                - conditions: "{{ repeat.item.call_type == 'matter' and 'all' in LEDnumber_effect }}"
+                - conditions: "{{ repeat.item.call_type == 'matter' and repeat.item.device_type == 'VTM31SN-115' }}"
+                  sequence:
+                    - service: light.turn_off
+                      data:
+                        entity_id: "{{ repeat.item.effect_color_entities }}"
+                - conditions: "{{ repeat.item.call_type == 'matter' and repeat.item.device_type != 'VTM31SN-115' }}"
                   sequence:
                     - service: light.turn_off
                       data:

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -24,7 +24,7 @@
 
 #
 # Effects not working?
-#   Black 500 and White Series devices do not support effects.
+#   Black 500 and White Series devices with firmware <1.1.5 do not support effects.
 #   Check that your device supports the effect you're selecting at https://inovelliusa.github.io/inovelli-switch-toolbox/
 #
 # Convert to blueprint:

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -29,7 +29,7 @@
 #
 # Convert to blueprint:
 #   Switch blueprint: and script alias: lines
-#   Add two spaces to lines between label: and variables: 71.664s
+#   Add two spaces to lines between label: and variables: 71.670s
 #   Comment out example:
 #   Switch input_* and script variables (1 place)
 #
@@ -444,8 +444,10 @@ fields:
           - Green
           - Cyan
           - Teal
+          - Aqua
           - Blue
           - Purple
+          - Violet
           - Magenta
           - Light Pink
           - Pink
@@ -485,8 +487,10 @@ fields:
           - Green
           - Cyan
           - Teal
+          - Aqua
           - Blue
           - Purple
+          - Violet
           - Magenta
           - Light Pink
           - Pink
@@ -609,8 +613,10 @@ fields:
           - Green
           - Cyan
           - Teal
+          - Aqua
           - Blue
           - Purple
+          - Violet
           - Magenta
           - Light Pink
           - Pink
@@ -678,8 +684,10 @@ variables:
     green: 85
     cyan: 127
     teal: 145
+    aqua: 160
     blue: 170
     purple: 190
+    violet: 200
     magenta: 212
     light pink: 220
     pink: 234
@@ -691,6 +699,7 @@ variables:
     "all custom on": "{{ LEDcolor_custom | default({'led 1':255,'led 2':255,'led 3':255,'led 4':255,'led 5':255,'led 6':255,'led 7':255,'all':0}) }}"
     "all custom off": "{{ LEDcolor_off_custom | default({'led 1':255,'led 2':255,'led 3':255,'led 4':255,'led 5':255,'led 6':255,'led 7':255,'all':0}) }}"
 
+  
   ### Blue Series ZHA Quirks says 1 – 7 but it seems to be 0 – 6 ###
   led_map:
     all: -1
@@ -1463,29 +1472,49 @@ variables:
   VTM31SN_all_effects:
     "off": 0
     clear effect: 0
-    aurora: 0
-    blink: 0
-    blink fast: 0
-    blink medium: 0
-    blink slow: 0
-    chase: 0
-    chase fast: 0
-    chase medium: 0
-    chase slow: 0
-    fall fast: 0
-    fall medium: 0
-    fall slow: 0
-    open close: 0
-    pulse: 0
-    rise fast: 0
-    rise medium: 0
-    rise slow: 0
-    siren fast: 0
-    siren slow: 0
-    small to big: 0
-    solid: 0
-    fast blink: 0
-    slow blink: 0
+    aurora: "Middle Chase"
+    blink: "Middle Blink"
+    blink fast: "Fast Blink"
+    blink medium: "Middle Blink"
+    blink slow: "Slow Blink"
+    chase: "Middle Chase"
+    chase fast: "Fast Chase"
+    chase medium: "Middle Chase"
+    chase slow: "Slow Chase"
+    fall fast: "Fast Falling"
+    fall medium: "Middle Falling"
+    fall slow: "Slow Falling"
+    open close: "Open Close"
+    pulse: "Middle Blink"
+    rise fast: "Fast Rising"
+    rise medium: "Middle Rising"
+    rise slow: "Slow Rising"
+    siren fast: "Fast Siren"
+    siren slow: "Slow Siren"
+    small to big: "Small To Big" 
+    solid: Solid
+    fast blink: "Fast Blink"
+    slow blink: "Slow Blink"
+
+  VTM31SN_colors:
+    red: Red
+    orange: Orange
+    lemon: Lemon
+    yellow: Lemon
+    lime: Lime
+    green: Green
+    cyan: Cyan
+    teal: Teal
+    aqua: Aqua
+    blue: Blue
+    purple: Magenta
+    violet: Violet
+    magenta: Magenta
+    light pink: Pink
+    pink: Pink
+    hot pink: Pink
+    white: White
+    "off": White
 
   ### White Series Fan ###
   VTM35SN_all_effects:
@@ -1514,6 +1543,7 @@ variables:
     solid: 0
     fast blink: 0
     slow blink: 0
+  
 
 
   ##################
@@ -2214,20 +2244,113 @@ sequence:
         ##################
         # Matter
         ##################
-        - device_type: VTM31SN
+        - device_type: VTM31SN-115
+          call_type: matter
+
+          effects: "{{ VTM31SN_all_effects[effect] }}"
+
+          entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') >= '1.1.0' %}
+                {% for led_bar in device_entities(device_id(ent)) %}
+                  {% if 'red' in state_attr(led_bar,'options') | lower and led_bar not in entities.entities %}
+                    {% set entities.entities = entities.entities + [led_bar] %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+          brightness_on_entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') >= '1.1.0' %}
+                {% for brightness_on in device_entities(device_id(ent)) %}
+                  {% if '100' in state_attr(brightness_on,'options') | lower and brightness_on.split('_')[-1] == 'on' and brightness_on not in entities.entities %}
+                    {% set entities.entities = entities.entities + [brightness_on] %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+          brightness_on_level: >-
+            {% set brightness = namespace(value=[0]) %}
+            {% for num in [0, 1, 3, 5, 8, 10, 13, 16, 20, 23, 26, 30, 33, 36, 40, 45, 50, 60, 70, 80, 90, 100] %}
+              {% if int(num,default=0) <= ((LEDbrightness | float) *10 | int) %}
+                {% set brightness.value = num %}
+              {% endif %}
+            {% endfor %}
+            {{ brightness.value }}
+
+          brightness_off_entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') >= '1.1.0' %}
+                {% for brightness_off in device_entities(device_id(ent)) %}
+                  {% if '100' in state_attr(brightness_off,'options') | lower and brightness_off.split('_')[-1] == 'off' and brightness_off not in entities.entities %}
+                    {% set entities.entities = entities.entities + [brightness_off] %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+          brightness_off_level: >-
+            {% set brightness = namespace(value=[0]) %}
+            {% for num in [0, 1, 3, 5, 8, 10, 13, 16, 20, 23, 26, 30, 33, 36, 40, 45, 50, 60, 70, 80, 90, 100] %}
+              {% if int(num,default=0) <= ((LEDbrightness_off | float) *10 | int) %}
+                {% set brightness.value = num %}
+              {% endif %}
+            {% endfor %}
+            {{ brightness.value }}
+
+          effect_color_entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for effect_color in all_selected_entities %}
+              {% if 'white series' in (device_attr(effect_color,'model') | lower ) and effect_color.split('.')[0] == 'light' and effect_color in integration_entities('matter') and 'color_temp' in state_attr(effect_color,'supported_color_modes') and
+                    device_attr(device_id(effect_color), 'sw_version') >= '1.1.0' %}
+                {% set entities.entities = entities.entities + [effect_color] %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+          effect_entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') >= '1.1.0' %}
+                {% for effect in device_entities(device_id(ent)) %}
+                  {% if 'solid' in state_attr(effect,'options')|lower and effect not in entities.entities %}
+                    {% set entities.entities = entities.entities + [effect] %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+
+        - device_type: VTM31SN-105
           call_type: matter
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'white series' in (device_attr(ent,'model') | lower ) and not 'color_temp' in state_attr(ent,'supported_color_modes') and ent.split('.')[0] == 'light' and ent in integration_entities('matter') %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and not 'color_temp' in state_attr(ent,'supported_color_modes') and ent.split('.')[0] == 'light' and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') < '1.1.0' %}
                 {% set entities.entities = entities.entities + ['select.' + ent.split('.')[1].split('_light_1')[0] + '_led_color'] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
+
           effect_entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'white series' in (device_attr(ent,'model') | lower ) and 'color_temp' in state_attr(ent,'supported_color_modes') and ent.split('.')[0] == 'light' and ent in integration_entities('matter') %}
+              {% if 'white series' in (device_attr(ent,'model') | lower ) and 'color_temp' in state_attr(ent,'supported_color_modes') and ent.split('.')[0] == 'light' and ent in integration_entities('matter') and
+                    device_attr(device_id(ent), 'sw_version') < '1.1.0' %}
                 {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
@@ -2243,6 +2366,7 @@ sequence:
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
+
           effect_entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
@@ -2443,7 +2567,15 @@ sequence:
                 ### Matter ###
                 ### White Series can't set individual LEDs so we'll filter out color sets and force 'all' ###
                 - choose:
-                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor and LEDnumber == 'all' }}"
+                    ### VTM31-SN FW >= 1.1.0
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor and LEDnumber == 'all' and repeat.item.device_type == 'VTM31SN-115' }}"
+                      sequence:
+                        - service: select.select_option
+                          data:
+                            option: "{{ VTM31SN_colors[LEDcolor] | capitalize }}"
+                            entity_id: "{{ repeat.item.entities }}"
+                    ### VTM31-SN FW < 1.0.5 and VTM35-SN
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor and LEDnumber == 'all' and repeat.item.device_type != 'VTM31SN-115' }}"
                       sequence:
                         - service: select.select_option
                           data:
@@ -2632,6 +2764,9 @@ sequence:
                                             {% endif %}
                                           manufacturer: 4655
 
+                ### Matter ###
+                ### Not supported ###
+
 
         ##################
         # LED strip brightness
@@ -2643,7 +2778,7 @@ sequence:
                 ### Zwave JS ###
                 ### Red Series can't set individual LEDs so we'll filter out color sets and force 'all'.  Prefer no action over partial implimentation of users' intents.  ###
                 - choose:
-                    - conditions: "{{ repeat.item.call_type == 'zwave_js' and 'all' in LEDnumber and 'all' not in LEDcolor and LEDnumber == 'all' }}"
+                    - conditions: "{{ repeat.item.call_type == 'zwave_js' and 'all' not in LEDcolor and LEDnumber == 'all' }}"
                       sequence:
                         - service: zwave_js.set_config_parameter
                           data:
@@ -2812,6 +2947,15 @@ sequence:
                                             {% endif %}
                                           value: "{{ iif(LEDcolor == 'all clear',101,(LEDbrightness * 10)) | int }}"
                                           manufacturer: 4655
+
+                ### Matter ###
+                - choose:
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor and LEDnumber == 'all' and repeat.item.device_type == 'VTM31SN-115' }}"
+                      sequence:
+                        - service: select.select_option
+                          data:
+                            option: "{{ iif(LEDcolor == 'off','0',int(repeat.item.brightness_on_level)) }}"
+                            entity_id: "{{ repeat.item.brightness_on_entities }}"
 
 
         ##################
@@ -2994,6 +3138,16 @@ sequence:
                                           value: "{{ iif(LEDcolor_off == 'all clear',101,(LEDbrightness_off * 10)) | int }}"
                                           manufacturer: 4655
 
+                ### Matter ###
+                - choose:
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' not in LEDcolor_off and LEDnumber == 'all' and repeat.item.device_type == 'VTM31SN-115' }}"
+                      sequence:
+                        - service: select.select_option
+                          data:
+                            option: "{{ iif(LEDcolor_off == 'off','0',int(repeat.item.brightness_off_level)) }}"
+                            entity_id: "{{ repeat.item.brightness_off_entities }}"
+
+
 
         #################
         # Effects (fully defined)
@@ -3002,7 +3156,7 @@ sequence:
         ##################
         - choose:
             - conditions: >-
-                {{ effect != "off" and effect != "clear effect" and color != "no change" and int(brightness) != 11 and
+                {{ effect != "off" and effect != "clear effect" and color != "no change" and int(brightness) != 11 and duration != 'off' and duration != 0 and 
                    repeat.item.device_type != "LZW30" and repeat.item.device_type != "LZW31" }}
               sequence:
 
@@ -3090,16 +3244,26 @@ sequence:
 
                 ### Matter ###
                 - choose:
-                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' in LEDnumber_effect and 'all' not in color }}"
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' in LEDnumber_effect and 'all' not in color and repeat.item.device_type == 'VTM31SN-115' }}"
                       sequence:
-                        ###  Brightness  ###
+
+                        ###  Effect color and brightness  ###
                         - service: light.turn_on
                           target:
-                            entity_id: "{{ repeat.item.effect_entities }}"
+                            entity_id: "{{ repeat.item.effect_color_entities }}"
                           data:
                             brightness_pct: "{{ (brightness * 10) | int }}"
+                            hs_color: "[{{ ((color_set[color] / 255)*360) | round(1) }}, 100 ]"
 
-                        ### White Series only supports the 'solid' effect ###
+                        ### Effect type ###
+                        - service: select.select_option
+                          data:
+                            option: "{{ repeat.item.effects }}"
+                            entity_id: "{{ repeat.item.effect_entities }}"
+
+                    ### VTM35-SN White Series Fan and VTM31-SN Dimmer FW <1.1.0 only supports the 'solid' effect ###
+                    - conditions: "{{ repeat.item.call_type == 'matter' and 'all' in LEDnumber_effect and 'all' not in color and repeat.item.device_type != 'VTM31SN-115' }}"
+                      sequence:
                         - service: light.turn_on
                           target:
                             entity_id: "{{ repeat.item.effect_entities }}"
@@ -3207,7 +3371,12 @@ sequence:
 
             ### Matter ###
             - choose:
-                - conditions: "{{ repeat.item.call_type == 'matter' and 'all' in LEDnumber_effect }}"
+                - conditions: "{{ repeat.item.call_type == 'matter' and repeat.item.device_type == 'VTM31SN-115' }}"
+                  sequence:
+                    - service: light.turn_off
+                      data:
+                        entity_id: "{{ repeat.item.effect_color_entities }}"
+                - conditions: "{{ repeat.item.call_type == 'matter' and repeat.item.device_type != 'VTM31SN-115' }}"
                   sequence:
                     - service: light.turn_off
                       data:


### PR DESCRIPTION
With firmware 1.1.5, VTM31-SN White Series dimmers support effects.  This is a breaking change to how the colors were handled in previous releases.  